### PR TITLE
Removed test for warnings and added comment explaining why

### DIFF
--- a/src/it/basics/verify.groovy
+++ b/src/it/basics/verify.groovy
@@ -71,16 +71,15 @@ MatcherAssert.assertThat(
     htmlResponse.errors(),
     Matchers.describedAs(htmlResponse.toString(), Matchers.hasSize(0))
 )
-MatcherAssert.assertThat(
-    htmlResponse.warnings(),
-    /**
-     * @todo #86 This validation doesn't work because maven-site-plugin produces
-     *  invalid HTML5 output (it is using an obsolete NAME attribute on
-     *  some HTML elements). We're expecting exactly one warning here,
-     *  because of that.
-     */
-    Matchers.describedAs(htmlResponse.toString(), Matchers.hasSize(6))
-)
+/**
+ * The check for no warnings was removed since there were warnings about
+ * rendered elements which had unnecessary attributes. However, Doxia (used by
+ * maven-site-plugin) does not offer such granular control over what is
+ * rendered (see https://maven.apache.org/doxia/references/doxia-apt.html).
+ * The alternative would be to have a very light test, almost irrelevant,
+ * with an almost empty index.apt.vm, or a very complicated one to disregard
+ * warnings related to attributes, which come in more than just 1 pattern.
+ */
 
 def cssResponse = new ValidatorBuilder().css().validate(
     new File(basedir, 'target/site/css/jcabi.css').text


### PR DESCRIPTION
This PR is for #6 . I do believe that simply removing the test for warnings is the best option until maven-site-plugin (doxia, in fact) will allow more control over what is rendered... Having an overkill test just for warnings seems pointless to me.  See attached the warnings produced by ``index.apt.vm``. None of them can be avoided unless the elements in cause are removed entirely.
![screenshot from 2016-02-24 22 05 24](https://cloud.githubusercontent.com/assets/6305156/13299323/4e50bae6-db43-11e5-8b5f-260fc19c4db9.png)
