### PR TITLE
fix(#74): update image source URL to resolve broken image issue

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -12,7 +12,7 @@
   <bannerLeft>
     <name>jcabi-maven-skin</name>
     <alt>jcabi</alt>
-    <src>https://www.jcabi.com/logo-square.svg</src>
+    <src>https://jcabi.com/logo-square.svg</src>
     <href>https://skin.jcabi.com/</href>
     <width>64</width>
     <height>64</height>


### PR DESCRIPTION
This PR fixes the broken image issue in `jcabi-maven-skin` by updating the image source URL.
By some reason, maven-site-plugin converts addresses with 'www' to local addresses.

 In other words it transforms `https://www.jcabi.com/logo-square.svg` to `../logo-square.svg`. With
`https://jcabi.com/logo-square.svg` everything works as expected.

Related to #74